### PR TITLE
Atualizado cargo de "Front-end" para "Full-stack"

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Se você tem espírito e comportamento empreendedor, muita disposição e proatividade para trabalhar em uma empresa em franca expansão, você é um forte candidato :)
 
-Como Desenvolvedor Front-end você irá trabalhar juntamente com uma excelente equipe de desenvolvedores ninja, tendo foco na criação produtos que garantam a melhor experiência para nossos usuários.
+Como Desenvolvedor Full-stack você irá trabalhar juntamente com uma excelente equipe de desenvolvedores ninja, tendo foco na criação produtos que garantam a melhor experiência para nossos usuários.
 
 ### O que fazem os Ninjas da Contabilizei? O que comem (e bebem)? Onde vivem?
 


### PR DESCRIPTION
O texto mencionava o cargo como "Front-end" mas nesse caso é para ser "Full-stack".

Preferência de casing e hifenização (Full Stack vs. Full-stack) foi copiado do post no Facebook.
